### PR TITLE
Update PointShapeLineExample.xaml

### DIFF
--- a/Examples/Wpf/CartesianChart/PointShapeLine/PointShapeLineExample.xaml
+++ b/Examples/Wpf/CartesianChart/PointShapeLine/PointShapeLineExample.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Wpf.CartesianChart.BasicLine"
+             xmlns:local="clr-namespace:Wpf.CartesianChart.PointShapeLine"
              xmlns:lvc="clr-namespace:LiveCharts.Wpf;assembly=LiveCharts.Wpf"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">


### PR DESCRIPTION
The example in the website make reference to this file, and it didn't compile because it was making reference to other namespace

#### Summary

*Explain the changes in this PR*

#### Solves 

*List the issues this PR solves, blank if none*
