### PR TITLE
implement dash stroke array for the legend

### DIFF
--- a/Examples/Wpf/CartesianChart/BasicLine/BasicLineExample.xaml.cs
+++ b/Examples/Wpf/CartesianChart/BasicLine/BasicLineExample.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows.Controls;
+using System.Windows.Media;
 using LiveCharts;
 using LiveCharts.Wpf;
 
@@ -16,12 +17,16 @@ namespace Wpf.CartesianChart.BasicLine
                 new LineSeries
                 {
                     Title = "Series 1",
-                    Values = new ChartValues<double> { 4, 6, 5, 2 ,7 }
+                    Values = new ChartValues<double> { 4, 6, 5, 2 ,7 },
+                    StrokeDashArray = new DoubleCollection{ 2, 2 }, //Dashed lines
+                    PointGeometry = null //PointGeometry set to null so that point markers do not appear
                 },
                 new LineSeries
                 {
                     Title = "Series 2",
-                    Values = new ChartValues<double> { 6, 7, 3, 4 ,6 }
+                    Values = new ChartValues<double> { 6, 7, 3, 4 ,6 },
+                    StrokeDashArray = new DoubleCollection{ 1, 1 }, //Dotted lines
+                    PointGeometry = null
                 }
             };
 
@@ -32,7 +37,8 @@ namespace Wpf.CartesianChart.BasicLine
             SeriesCollection.Add(new LineSeries
             {
                 Values = new ChartValues<double> {5, 3, 2, 4},
-                LineSmoothness = 0 //straight lines, 1 really smooth lines
+                LineSmoothness = 0, //straight lines, 1 really smooth lines
+                PointGeometry = null
             });
 
             //modifying any series values will also animate and update the chart

--- a/WpfView/Charts/Base/Chart.cs
+++ b/WpfView/Charts/Base/Chart.cs
@@ -973,6 +973,7 @@ namespace LiveCharts.Wpf.Charts.Base
                                 : ((Series) x.SeriesView).Fill,
                             Stroke = ((Series) x.SeriesView).Stroke,
                             StrokeThickness = ((Series) x.SeriesView).StrokeThickness,
+                            StrokeDashArray = ((Series) x.SeriesView).StrokeDashArray,
                             Title = ((Series) x.SeriesView).Title,
                         },
                         ChartPoint = x
@@ -1059,6 +1060,7 @@ namespace LiveCharts.Wpf.Charts.Base
                     ? ((IFondeable) t).PointForeground
                     : ((Series) t).Fill;
                 item.PointGeometry = series.PointGeometry ?? Geometry.Parse("M0,0 L1,0");
+                item.StrokeDashArray = series.StrokeDashArray != null? new DoubleCollection{1,1} : null;
 
                 l.Add(item);
             }

--- a/WpfView/DefaultLegend.xaml
+++ b/WpfView/DefaultLegend.xaml
@@ -64,7 +64,8 @@
                                          Height="{Binding BulletSize, RelativeSource={RelativeSource Mode=FindAncestor, AncestorLevel=1, AncestorType={x:Type UserControl}}}" 
                                          StrokeThickness="{Binding StrokeThickness}" 
                                          Stroke="{Binding Stroke}" Fill="{Binding Fill}"
-                                         Stretch="Fill" Data="{Binding PointGeometry}"/>
+                                         Stretch="Fill" Data="{Binding PointGeometry}"
+                                         StrokeDashArray="{Binding StrokeDashArray}"/>
                                 <TextBlock Grid.Column="1" Margin="4 0" Text="{Binding Title}" VerticalAlignment="Center" />
                             </Grid>
                         </DataTemplate>

--- a/WpfView/DefaultTooltip.xaml.cs
+++ b/WpfView/DefaultTooltip.xaml.cs
@@ -434,6 +434,10 @@ namespace LiveCharts.Wpf
         /// </summary>
         public double StrokeThickness { get; set; }
         /// <summary>
+        /// Series Stroke Dash Array
+        /// </summary>
+        public DoubleCollection StrokeDashArray { get; set; }
+        /// <summary>
         /// Series Fill
         /// </summary>
         public Brush Fill { get; set; }


### PR DESCRIPTION
#### Summary

Currently if a line series gets added with a dashed line, the series appears as solid in the legend. This can be confusing if you have two lines with the same color, and use dash type to differentiate them.

#### Solves 

fixes issue #843
