### PR TITLE
Fixed bug fill and stroke of RowPointView in StackedRowSeries.cs

### DIFF
--- a/WpfView/PieSeries.cs
+++ b/WpfView/PieSeries.cs
@@ -173,6 +173,9 @@ namespace LiveCharts.Wpf
                 pbv.DataLabel = null;
             }
 
+            if (point.Stroke != null) pbv.Slice.Stroke = (Brush)point.Stroke;
+            if (point.Fill != null) pbv.Slice.Fill = (Brush)point.Fill;
+
             pbv.OriginalPushOut  = PushOut;
 
             return pbv;

--- a/WpfView/StackedRowSeries.cs
+++ b/WpfView/StackedRowSeries.cs
@@ -215,6 +215,9 @@ namespace LiveCharts.Wpf
                 pbv.DataLabel = null;
             }
 
+            if (point.Stroke != null) pbv.Rectangle.Stroke = (Brush)point.Stroke;
+            if (point.Fill != null) pbv.Rectangle.Fill = (Brush)point.Fill;
+
             pbv.LabelPosition = LabelsPosition;
 
             return pbv;


### PR DESCRIPTION
#### Summary

Fixes bug #847.
Fill and Stroke are now displayed in StackedRowSeries.

#### Solves 

Fixes bug #847.

#### Further Information

I just copied the missing code from RowSeries.cs into StackedRowSeries.cs. I set up a test project, which worked. I used the Example PointState ([https://github.com/Live-Charts/Live-Charts/tree/master/Examples/Wpf/CartesianChart/PointState](url)) and changed RowSeries to StackedRowSeries in the xaml-File. It worked as expected.