### PR TITLE
Designer keeps throwing this error.

### DIFF
--- a/Core/Charts/CartesianChartCore.cs
+++ b/Core/Charts/CartesianChartCore.cs
@@ -118,7 +118,7 @@ namespace LiveCharts.Charts
                         if (double.IsNaN(yi.MaxValue)) yi.TopLimit += yi.S;
                         else yi.TopLimit = yi.MaxValue;
 
-                        if (Math.Abs(yi.BotLimit - yi.TopLimit) < yi.S * .01)
+                        if (Math.Abs(yi.BotLimit - yi.TopLimit) < yi.S * .01 && !View.IsInDesignMode)
                             throw new LiveChartsException("One axis has an invalid range, it is or it " +
                                                           "tends to zero, please ensure your axis has a valid " +
                                                           "range");


### PR DESCRIPTION
 When binding to MaxValue or MinValue for an axis this error keeps cropping up with a stacktrace.

#### Summary

Added the !View.IsInDesignMode check on the y-axis just like the x axis.
#### Solves 

Designer in Visual Studio continuously throwing an exception.
