### PR TITLE
Fixes the bug of showing 0.00 participation in default tool tip

### DIFF
--- a/WpfView/DefaultTooltip.xaml
+++ b/WpfView/DefaultTooltip.xaml
@@ -99,8 +99,8 @@
                                         <TextBlock Grid.Column="3" Text="{Binding ChartPoint.Participation, StringFormat={}{0:P}}" 
                                                VerticalAlignment="Center" Margin="5 0 0 0"
                                                Visibility="{Binding DataContext.Data, RelativeSource={RelativeSource  FindAncestor, 
-                                                                                                    AncestorType={x:Type StackPanel}}, 
-                                                                    Converter={StaticResource ParticipationVisibilityConverter}}"/>
+                                                            AncestorType={x:Type ItemsControl}}, 
+                                                            Converter={StaticResource ParticipationVisibilityConverter}}"/>
                                     </Grid>
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>


### PR DESCRIPTION
#### Summary

The FindAncestor binding doesn't work as expected before. The changed version fixes the binding and correctly hides 0 values of participation. 

#### Solves 

#961
