### PR TITLE
Fix #696: Dragging outside chart should stop the drag

### DIFF
--- a/WpfView/Charts/Base/Chart.cs
+++ b/WpfView/Charts/Base/Chart.cs
@@ -106,6 +106,7 @@ namespace LiveCharts.Wpf.Charts.Base
             DrawMargin.Background = Brushes.Transparent; // if this line is not set, then it does not detect mouse down event...
             DrawMargin.MouseDown += OnDraggingStart;
             DrawMargin.MouseUp += OnDraggingEnd;
+            DrawMargin.MouseLeave += OnDraggingEnd;
             DrawMargin.MouseMove += DragSection;
             DrawMargin.MouseMove += PanOnMouseMove;
             MouseUp += DisableSectionDragMouseUp;


### PR DESCRIPTION
#### Summary  
Make a chart draggable.  
Drag to outside window or outside chart and release.  
Mouse over chart again, it will keep acting like you are dragging until you click and release.  
#### Solves 
Mouse Leave event end dragging as a normal click release.
Fix WPF ONLY.
