### PR TITLE
Fix #696: Dragging outside chart should stop the drag

### DIFF
--- a/WpfView/Charts/Base/Chart.cs
+++ b/WpfView/Charts/Base/Chart.cs
@@ -1259,6 +1259,11 @@ namespace LiveCharts.Wpf.Charts.Base
             DragOrigin = end;
         }
 
+        private void OnDraggingEnd(object sender, MouseEventArgs e)
+        {
+            if (!IsPanning) return;
+            IsPanning = false;
+        }
         private void OnDraggingEnd(object sender, MouseButtonEventArgs e)
         {
             if (!IsPanning) return;


### PR DESCRIPTION
### Summary  
Make a chart draggable.  
Drag to outside window or outside chart and release.  
Mouse over chart again, it will keep acting like you are dragging until you click and release.  
### Solves  
Mouse Leave event end dragging as a normal click release.  
Fix WPF ONLY.  

*I am so sorry that I didn't test well last time. *