### PR TITLE
New options for bar chart data label placement

### DIFF
--- a/Core40/BarLabelPosition.cs
+++ b/Core40/BarLabelPosition.cs
@@ -39,12 +39,20 @@ namespace LiveCharts
         [Obsolete("Instead use BarLabelPosition.Parallel")]
         Merged,
         /// <summary>
-        /// Places a labels in a parallel orientation to the bar height.
+        /// Places a labels in a parallel orientation to the bar height, at the center.
         /// </summary>
         Parallel,
-        /// <summary>
-        /// Places a labels in a perpendicular orientation to the bar height.
-        /// </summary>
-        Perpendicular
-    }
+		/// <summary>
+		/// If the bar is a column, places labels in parallel orientation to the bar height, at the top. If the bar is a row, places labels in parallel orientation to the bar width, at the right.
+		/// </summary>
+		ParallelTopRight,
+		/// <summary>
+		/// If the bar is a column, places labels in parallel orientation to the bar height, at the bottom. If the bar is a row, places labels in parallel orientation to the bar width, at the left.
+		/// </summary>
+		ParallelBottomLeft,
+		/// <summary>
+		/// Places a labels in a perpendicular orientation to the bar height.
+		/// </summary>
+		Perpendicular
+	}
 }

--- a/Core40/BarLabelPosition.cs
+++ b/Core40/BarLabelPosition.cs
@@ -42,17 +42,17 @@ namespace LiveCharts
         /// Places a labels in a parallel orientation to the bar height, at the center.
         /// </summary>
         Parallel,
-		/// <summary>
-		/// If the bar is a column, places labels in parallel orientation to the bar height, at the top. If the bar is a row, places labels in parallel orientation to the bar width, at the right.
-		/// </summary>
-		ParallelTopRight,
-		/// <summary>
-		/// If the bar is a column, places labels in parallel orientation to the bar height, at the bottom. If the bar is a row, places labels in parallel orientation to the bar width, at the left.
-		/// </summary>
-		ParallelBottomLeft,
-		/// <summary>
-		/// Places a labels in a perpendicular orientation to the bar height.
-		/// </summary>
-		Perpendicular
-	}
+        /// <summary>
+        /// If the bar is a column, places labels in parallel orientation to the bar height, at the top. If the bar is a row, places labels in parallel orientation to the bar width, at the right.
+        /// </summary>
+        ParallelTopRight,
+        /// <summary>
+        /// If the bar is a column, places labels in parallel orientation to the bar height, at the bottom. If the bar is a row, places labels in parallel orientation to the bar width, at the left.
+        /// </summary>
+        ParallelBottomLeft,
+        /// <summary>
+        /// Places a labels in a perpendicular orientation to the bar height.
+        /// </summary>
+        Perpendicular
+    }
 }

--- a/WpfView/Points/ColumnPointView.cs
+++ b/WpfView/Points/ColumnPointView.cs
@@ -68,21 +68,21 @@ namespace LiveCharts.Wpf.Points
                     if (Transform == null)
                         Transform = new RotateTransform(270);
 
-					DataLabel.RenderTransform = Transform;
+                    DataLabel.RenderTransform = Transform;
 
-					if (LabelPosition == BarLabelPosition.ParallelTopRight)
-					{
-						y = Data.Top + DataLabel.ActualWidth;
-					}
-					else if (LabelPosition == BarLabelPosition.ParallelBottomLeft)
-					{
-						y = Data.Top + Data.Height;
-					}
-					else
-					{
-						y = Data.Top + Data.Height / 2 + DataLabel.ActualWidth * .5;
-					}
-				}
+                    if (LabelPosition == BarLabelPosition.ParallelTopRight)
+                    {
+                        y = Data.Top + DataLabel.ActualWidth;
+                    }
+                    else if (LabelPosition == BarLabelPosition.ParallelBottomLeft)
+                    {
+                        y = Data.Top + Data.Height;
+                    }
+                    else
+                    {
+                        y = Data.Top + Data.Height / 2 + DataLabel.ActualWidth * .5;
+                    }
+                }
                 else if (LabelPosition == BarLabelPosition.Perpendicular)
                 {
                     y = Data.Top + Data.Height/2 - DataLabel.ActualHeight * .5;

--- a/WpfView/Points/ColumnPointView.cs
+++ b/WpfView/Points/ColumnPointView.cs
@@ -62,15 +62,27 @@ namespace LiveCharts.Wpf.Points
                 double y;
 
 #pragma warning disable 618
-                if (LabelPosition == BarLabelPosition.Parallel || LabelPosition == BarLabelPosition.Merged)
+                if (LabelPosition == BarLabelPosition.Parallel || LabelPosition == BarLabelPosition.ParallelTopRight || LabelPosition == BarLabelPosition.ParallelBottomLeft || LabelPosition == BarLabelPosition.Merged)
 #pragma warning restore 618
                 {
                     if (Transform == null)
                         Transform = new RotateTransform(270);
 
-                    y = Data.Top + Data.Height/2 + DataLabel.ActualWidth*.5;
-                    DataLabel.RenderTransform = Transform;
-                }
+					DataLabel.RenderTransform = Transform;
+
+					if (LabelPosition == BarLabelPosition.ParallelTopRight)
+					{
+						y = Data.Top + DataLabel.ActualWidth;
+					}
+					else if (LabelPosition == BarLabelPosition.ParallelBottomLeft)
+					{
+						y = Data.Top + Data.Height;
+					}
+					else
+					{
+						y = Data.Top + Data.Height / 2 + DataLabel.ActualWidth * .5;
+					}
+				}
                 else if (LabelPosition == BarLabelPosition.Perpendicular)
                 {
                     y = Data.Top + Data.Height/2 - DataLabel.ActualHeight * .5;
@@ -97,7 +109,7 @@ namespace LiveCharts.Wpf.Points
                 double x;
 
 #pragma warning disable 618
-                if (LabelPosition == BarLabelPosition.Parallel || LabelPosition == BarLabelPosition.Merged)
+                if (LabelPosition == BarLabelPosition.Parallel || LabelPosition == BarLabelPosition.ParallelTopRight || LabelPosition == BarLabelPosition.ParallelBottomLeft || LabelPosition == BarLabelPosition.Merged)
 #pragma warning restore 618
                 {
                     x = Data.Left + Data.Width/2 - DataLabel.ActualHeight/2;

--- a/WpfView/Points/RowPointView.cs
+++ b/WpfView/Points/RowPointView.cs
@@ -87,6 +87,14 @@ namespace LiveCharts.Wpf.Points
                 {
                     r = Data.Left + Data.Width/2 - DataLabel.ActualWidth/2;
                 }
+				else if (LabelPosition == BarLabelPosition.ParallelTopRight)
+				{
+					r = Data.Left + Data.Width - DataLabel.ActualWidth;
+				}
+				else if (LabelPosition == BarLabelPosition.ParallelBottomLeft)
+				{
+					r = Data.Left;
+				}
                 else if (LabelPosition == BarLabelPosition.Perpendicular)
                 {
                     r = Data.Left + Data.Width/2 - DataLabel.ActualHeight/2;

--- a/WpfView/Points/RowPointView.cs
+++ b/WpfView/Points/RowPointView.cs
@@ -87,14 +87,14 @@ namespace LiveCharts.Wpf.Points
                 {
                     r = Data.Left + Data.Width/2 - DataLabel.ActualWidth/2;
                 }
-				else if (LabelPosition == BarLabelPosition.ParallelTopRight)
-				{
-					r = Data.Left + Data.Width - DataLabel.ActualWidth;
-				}
-				else if (LabelPosition == BarLabelPosition.ParallelBottomLeft)
-				{
-					r = Data.Left;
-				}
+                else if (LabelPosition == BarLabelPosition.ParallelTopRight)
+                {
+                    r = Data.Left + Data.Width - DataLabel.ActualWidth;
+                }
+                else if (LabelPosition == BarLabelPosition.ParallelBottomLeft)
+                {
+                    r = Data.Left;
+                }
                 else if (LabelPosition == BarLabelPosition.Perpendicular)
                 {
                     r = Data.Left + Data.Width/2 - DataLabel.ActualHeight/2;


### PR DESCRIPTION
#### Summary

Currently bar chart data label placement are Top, Merged (obsolete), Parallel and Perpendicular. Parallel placement matches data label center with bar center. I was missing other alignments, so I created two new options, one for each ending of the bar:

- ParallelTopRight: same as Parallel, except it matches data label's top with column's top and label's right with row's right.
- ParallelBottomLeft: same as Parallel, except it matches data label's bottom with column's bottom, and label's right with row's right.

#### Solves 

#691, but not entirely, I guess.