### PR TITLE
Fix: performance issue in LiveCharts.Wpf.DefaultLegend

### DIFF
--- a/WpfView/DefaultLegend.xaml.cs
+++ b/WpfView/DefaultLegend.xaml.cs
@@ -37,6 +37,17 @@ namespace LiveCharts.Wpf
     {
         private List<SeriesViewModel> _series;
 
+        private bool HasSeriesItemsChanged(List<SeriesViewModel> newSeries)
+        {
+            if (_series == null)
+                return true;
+            
+            if (newSeries.Count != _series.Count)
+                return true;
+
+            return newSeries.Select(newItem => Enumerable.Contains(_series, newItem)).Any(found => !found);
+        }
+
         /// <summary>
         /// Initializes a new instance of DefaultLegend class
         /// </summary>
@@ -60,8 +71,11 @@ namespace LiveCharts.Wpf
             get { return _series; }
             set
             {
-                _series = value;
-                OnPropertyChanged("Series");
+                if (HasSeriesItemsChanged(value))
+                {
+                    _series = value;
+                    OnPropertyChanged("Series");
+                }  
             }
         }
 

--- a/WpfView/DefaultTooltip.xaml.cs
+++ b/WpfView/DefaultTooltip.xaml.cs
@@ -441,6 +441,21 @@ namespace LiveCharts.Wpf
         /// Series point Geometry
         /// </summary>
         public Geometry PointGeometry { get; set; }
+        
+         /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            var item = obj as SeriesViewModel;
+            if (item == null)
+                return false;
+            
+            return Fill == item.Fill
+                   && Stroke == item.Stroke
+                   && Title == item.Title
+                   && (PointGeometry == null || item.PointGeometry == null
+                                             || PointGeometry.Bounds == item.PointGeometry.Bounds && PointGeometry.Transform == item.PointGeometry.Transform)
+                   && StrokeThickness == item.StrokeThickness;
+        }
     }
 
 }


### PR DESCRIPTION
#### Summary

Fixed a performance issue in the DefaultLegend. Whenever the setter of the property "Series" was called, the PropertyChanged event was invoked, which leads to a redrawing of the whole legend. In my demo project, I had plotted about 35 different lines in a CartesianChart and updated it every 10ms with multiple sensor data. The redrawing of the legend, whenever a new sensor data item is available, would completely freeze the UI. Applying the fix, legend is still up-to-date and UI won't freeze.


#### Solves 

- performance issue caused by not required updates of the chart legend
